### PR TITLE
fix: parseFloat convertToBase return

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class Unit {
 
     if (type === 'cost') return value / this.conversion;
     if (type === 'quantity') return value * this.conversion;
-    return value;
+    return parseFloat(value);
   }
 
   convertFromBase(type, value, round = false) {


### PR DESCRIPTION
Worked with @nkajokcurate yesterday on this fix. This change allows the comparison in the `auto-save-mixin` to compare the cost of the recipeIngredient with the correct value from the input. We trigger a `recipeIngredientUpdate` when the comparison is different, so there would be an update call for every single recipe ingredient on the page. 

Before: '1' === '1.00'
After: '1.00' === '1.00'

Opening as a draft pr for now since there isn't a staging branch in this repo. Waiting to see if we are okay with merging into master, or if we want to create a staging branch for this.